### PR TITLE
Add playback range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <name>AudioPlayer Add-on</name>
 
     <properties>
-        <vaadin.version>14.7.1</vaadin.version>
+        <vaadin.version>14.8.3</vaadin.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/org/vaadin/addon/audio/server/AudioPlayer.java
+++ b/src/main/java/org/vaadin/addon/audio/server/AudioPlayer.java
@@ -424,6 +424,9 @@ public class AudioPlayer extends PolymerTemplate<TemplateModel> {
         return StringFormatter.msToPlayerTimeStamp(getDuration());
     }
     
+    /**
+     * Gets the start of the audio play range.
+     */
     public int getStartRange() {
       return startRange;
     }
@@ -441,6 +444,9 @@ public class AudioPlayer extends PolymerTemplate<TemplateModel> {
       }     
     }
 
+    /**
+     * Gets the end of the audio player range.
+     */
     public int getEndRange() {
       return endRange;
     }
@@ -458,11 +464,20 @@ public class AudioPlayer extends PolymerTemplate<TemplateModel> {
       } 
     }    
     
-
+    /**
+     * Gets the enum representing the action that should happen when playback
+     * reaches the end of the range.
+     */
     public OnEndOfRange getOnEndOfRange() {
       return onEndOfRange;
     }
 
+    /**
+     * Sets the enum value that represents the action to be applied when playback 
+     * reaches the end of the range.
+     * 
+     * @param onEndOfRange 
+     */
     public void setOnEndOfRange(OnEndOfRange onEndOfRange) {
       this.onEndOfRange = onEndOfRange;
       this.getElement().setProperty("onEndOfRange", onEndOfRange.getAction());

--- a/src/main/java/org/vaadin/addon/audio/server/AudioPlayer.java
+++ b/src/main/java/org/vaadin/addon/audio/server/AudioPlayer.java
@@ -437,9 +437,6 @@ public class AudioPlayer extends PolymerTemplate<TemplateModel> {
       if(startRange >= 0 && startRange < this.getDuration()) {
         this.startRange = startRange;
         this.getElement().setProperty("startRange", startRange);
-
-        this.setPosition(startRange);
-
         Log.message(AudioPlayer.this, "setting start range to " + startRange);
       }     
     }

--- a/src/main/java/org/vaadin/addon/audio/server/AudioPlayer.java
+++ b/src/main/java/org/vaadin/addon/audio/server/AudioPlayer.java
@@ -14,6 +14,7 @@ import elemental.json.JsonObject;
 import org.vaadin.addon.audio.server.state.PlaybackState;
 import org.vaadin.addon.audio.server.state.StateChangeCallback;
 import org.vaadin.addon.audio.server.state.VolumeChangeCallback;
+import org.vaadin.addon.audio.server.util.OnEndOfRange;
 import org.vaadin.addon.audio.server.util.StringFormatter;
 import org.vaadin.addon.audio.shared.ChunkDescriptor;
 import org.vaadin.addon.audio.shared.SharedEffect;
@@ -51,6 +52,12 @@ public class AudioPlayer extends PolymerTemplate<TemplateModel> {
 
     public final List<SharedEffect> effects = new ArrayList<SharedEffect>();
 
+    public int startRange;
+
+    public int endRange;
+        
+    public OnEndOfRange onEndOfRange;    
+
     /**
      * Create new AudioPlayer
      *
@@ -79,6 +86,11 @@ public class AudioPlayer extends PolymerTemplate<TemplateModel> {
         setStream(stream);
 
         getElement().setProperty("reportPositionRepeatTime", reportPositionRepeatTime);
+        
+        // Set default values for range
+        setStartRange(0);
+        setEndRange(this.duration);
+        setOnEndOfRange(OnEndOfRange.STOP_POSITION_END);       
     }
 
     @ClientCallable
@@ -410,6 +422,54 @@ public class AudioPlayer extends PolymerTemplate<TemplateModel> {
      */
     public String getDurationString() {
         return StringFormatter.msToPlayerTimeStamp(getDuration());
+    }
+    
+    public int getStartRange() {
+      return startRange;
+    }
+
+    /**
+     * Sets the start of the audio play range.
+     * 
+     * @param startRange
+     */
+    public void setStartRange(int startRange) {
+      if(startRange >= 0 && startRange < this.getDuration()) {
+        this.startRange = startRange;
+        this.getElement().setProperty("startRange", startRange);
+
+        this.setPosition(startRange);
+
+        Log.message(AudioPlayer.this, "setting start range to " + startRange);
+      }     
+    }
+
+    public int getEndRange() {
+      return endRange;
+    }
+
+    /**
+     * Sets the end of the audio play range.
+     * 
+     * @param endRange
+     */
+    public void setEndRange(int endRange) {
+      if(endRange > 0 && endRange <= this.getDuration()) {
+        this.endRange = endRange;
+        this.getElement().setProperty("endRange", endRange);
+        Log.message(AudioPlayer.this, "setting end range to " + endRange);
+      } 
+    }    
+    
+
+    public OnEndOfRange getOnEndOfRange() {
+      return onEndOfRange;
+    }
+
+    public void setOnEndOfRange(OnEndOfRange onEndOfRange) {
+      this.onEndOfRange = onEndOfRange;
+      this.getElement().setProperty("onEndOfRange", onEndOfRange.getAction());
+      Log.message(AudioPlayer.this, "setting action to do when reaching end of range to " + onEndOfRange);
     }
 
     // =========================================================================

--- a/src/main/java/org/vaadin/addon/audio/server/util/OnEndOfRange.java
+++ b/src/main/java/org/vaadin/addon/audio/server/util/OnEndOfRange.java
@@ -1,0 +1,18 @@
+package org.vaadin.addon.audio.server.util;
+
+public enum OnEndOfRange {
+  
+  STOP_POSITION_END(0), STOP_POSITION_START(1), LOOP_POSITION_START(2);
+  
+  private int action;
+
+  OnEndOfRange(int action) {
+    this.action = action;
+  }
+
+  public int getAction() {
+    return action;
+  }
+  
+  
+}

--- a/src/main/java/org/vaadin/addon/audio/server/util/OnEndOfRange.java
+++ b/src/main/java/org/vaadin/addon/audio/server/util/OnEndOfRange.java
@@ -1,5 +1,14 @@
 package org.vaadin.addon.audio.server.util;
 
+/**
+ * Enum representing what should happen when playback reaches the end of the range.
+ * There are tree options:
+ * <ul>
+ * <li> stop, leaving the playback position at the end of the range (0)
+ * <li> stop, resetting the playback position at the start of the range (1)
+ * <li> loop, resetting the playback position to the start of the range and continuing play (2)
+ * </ul> 
+ */
 public enum OnEndOfRange {
   
   STOP_POSITION_END(0), STOP_POSITION_START(1), LOOP_POSITION_START(2);

--- a/src/main/resources/META-INF/resources/frontend/audio-player.js
+++ b/src/main/resources/META-INF/resources/frontend/audio-player.js
@@ -50,7 +50,10 @@ class AudioPlayer extends PolymerElement {
                 value: 500
             },
             _reportPositionRepeatInterval: Number,
-            _lastPlaybackPosition: Number
+            _lastPlaybackPosition: Number,
+            startRange: Number,
+            endRange: Number,
+            onEndOfRange: Number
         };
     }
 
@@ -88,11 +91,11 @@ class AudioPlayer extends PolymerElement {
         // console.table(chunks);
 
         this._stream = new ClientStream(this._context, this);
-        this._player = new AudioStreamPlayer(this._context, this._stream, this.chunkTimeMillis);
+        this._player = new AudioStreamPlayer(this._context, this._stream, this.chunkTimeMillis, this.startRange, this.endRange, this.onEndOfRange);
         this._player.connect(this._context.destination);
         this._player.onStop = () => {
             this.$server.reportPlaybackStopped();
-            // this.$server.reportPlaybackPosition(this._player.position);
+            this.$server.reportPlaybackPosition(this._player.position);
             this._cancelPositionReportSchedule();
         };
     }

--- a/src/main/resources/META-INF/resources/frontend/audio-player.js
+++ b/src/main/resources/META-INF/resources/frontend/audio-player.js
@@ -59,7 +59,8 @@ class AudioPlayer extends PolymerElement {
 
     static get observers() {
         return [
-            '_updateStream(chunks, chunkTimeMillis)'
+            '_updateStream(chunks, chunkTimeMillis)',
+            '_updateValues(startRange, endRange, onEndOfRange)'
         ];
     }
 
@@ -78,6 +79,14 @@ class AudioPlayer extends PolymerElement {
         }
     }
 
+    _updateValues(startRange, endRange, onEndOfRange) {
+        if (this._player) {
+            this._player._startRange = startRange;
+            this._player._endRange = endRange;
+            this._player._onEndOfRange = onEndOfRange;
+        }
+    }
+
     _updateStream(chunks, chunkTimeMillis) {
         if (chunks === undefined || chunkTimeMillis === undefined) {
             return;
@@ -91,7 +100,7 @@ class AudioPlayer extends PolymerElement {
         // console.table(chunks);
 
         this._stream = new ClientStream(this._context, this);
-        this._player = new AudioStreamPlayer(this._context, this._stream, this.chunkTimeMillis, this.startRange, this.endRange, this.onEndOfRange);
+        this._player = new AudioStreamPlayer(this._context, this._stream, chunkTimeMillis, this.startRange, this.endRange, this.onEndOfRange);
         this._player.connect(this._context.destination);
         this._player.onStop = () => {
             this.$server.reportPlaybackStopped();

--- a/src/main/resources/META-INF/resources/frontend/audio-player.js
+++ b/src/main/resources/META-INF/resources/frontend/audio-player.js
@@ -60,7 +60,7 @@ class AudioPlayer extends PolymerElement {
     static get observers() {
         return [
             '_updateStream(chunks, chunkTimeMillis)',
-            '_updateValues(startRange, endRange, onEndOfRange)'
+            '_updateRangeValues(startRange, endRange, onEndOfRange)'
         ];
     }
 
@@ -79,7 +79,7 @@ class AudioPlayer extends PolymerElement {
         }
     }
 
-    _updateValues(startRange, endRange, onEndOfRange) {
+    _updateRangeValues(startRange, endRange, onEndOfRange) {
         if (this._player) {
             this._player._startRange = startRange;
             this._player._endRange = endRange;

--- a/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
+++ b/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
@@ -179,8 +179,8 @@ export const AudioStreamPlayer = (() => {
                 this._playerManager.currentPlayer.playByDuration(this._chunkPosition, this._chunkStartTime / 1000, lastChunkDuration / 1000);
             } else {
                 this._playerManager.currentPlayer.play(this._chunkPosition, this._chunkStartTime / 1000);
-            }
-            this._startNextChunkScheduling();
+                this._startNextChunkScheduling();
+            }            
 
             const nextChunkTime = Math.min(
                 /*this.duration*/this._endRange,
@@ -320,7 +320,13 @@ export const AudioStreamPlayer = (() => {
          */
         get _currentChunkDuration() {
             if (this._playerManager.currentPlayer.buffer) {
-                return this._playerManager.currentPlayer.buffer.duration * 1000;
+                const nextChunkLength = this._position + this._timePerChunk;
+                if(nextChunkLength > this._endRange){
+                    const lastChunkDuration = this._endRange - this._position;  
+                    return Math.min(lastChunkDuration, this._playerManager.currentPlayer.buffer.duration * 1000);
+                } else {    
+                    return this._playerManager.currentPlayer.buffer.duration * 1000;
+                }
             } else {
                 // No chunk yet, assume infinite duration
                 return Infinity;

--- a/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
+++ b/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
@@ -104,9 +104,8 @@ export const AudioStreamPlayer = (() => {
                 }
             }
 
-            if (timeOffset < 0 || this._position + timeOffset >= /*this.duration*/this._endRange) {
+            if (timeOffset < 0 || this._position + timeOffset >= this._endRange) {
                 // Start offset is outside the range
-                // return;
                 switch (this._onEndOfRange) {
                     case 0:
                         this._position = this._endRange;
@@ -200,10 +199,10 @@ export const AudioStreamPlayer = (() => {
             }            
 
             const nextChunkTime = Math.min(
-                /*this.duration*/this._endRange,
+                this._endRange,
                 this._position + this._timePerChunk + this._chunkOverlapTime
             );
-            if (nextChunkTime < /*this.duration*/this._endRange) {
+            if (nextChunkTime < this._endRange) {
                 this._fetchChunksForNextPlayer(nextChunkTime);
             }
         }
@@ -366,7 +365,6 @@ export const AudioStreamPlayer = (() => {
             const nextChunkOffset = this._position + this._currentChunkDuration;
             if (nextChunkOffset >= this._endRange) {
                 // console.warn("to stop");
-                // this.stop();
                 switch (this._onEndOfRange) {
                     case 0:
                         this._position = this._endRange;
@@ -476,7 +474,7 @@ export const AudioStreamPlayer = (() => {
 
         get position() {
             const position = this._position + this._currentChunkPosition;
-            return Math.min(position, /*this.duration*/this._endRange);
+            return Math.min(position, this._endRange);
         }
 
         /**

--- a/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
+++ b/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
@@ -106,7 +106,24 @@ export const AudioStreamPlayer = (() => {
 
             if (timeOffset < 0 || this._position + timeOffset >= /*this.duration*/this._endRange) {
                 // Start offset is outside the range
-                return;
+                // return;
+                switch (this._onEndOfRange) {
+                    case 0:
+                        this._position = this._endRange;
+                        this._stopOnRangeEnd();
+                        return;
+                    case 1:
+                        this._position = 0;
+                        this._stopOnRangeEnd();
+                        return;
+                    case 2:
+                        this._position = 0;
+                        this._loopOnRangeEnd();
+                        this.play();
+                        return;            
+                    default:
+                        return;
+                };
             }
 
             if (isChunkTransition && this._chunkStartTime !== undefined) {

--- a/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
+++ b/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
@@ -96,7 +96,7 @@ export const AudioStreamPlayer = (() => {
                     return;
                 }
 
-                var startTime = this.position>=this._startRange?this.position:this._startRange;
+                const startTime = this.position >= this._startRange ? this.position : this._startRange;
                 timeOffset = startTime % this._timePerChunk;
             } else {
                 if (this._playerManager.currentPlayer.isScheduled) {
@@ -341,21 +341,15 @@ export const AudioStreamPlayer = (() => {
                 switch (this._onEndOfRange) {
                     case 0:
                         this._position = this._endRange;
-                        this.stopOnRangeEndDefault();
+                        this._stopOnRangeEnd();
                         break;
                     case 1:
                         this._position = 0;
-                        this.stopOnRangeEndDefault();
+                        this._stopOnRangeEnd();
                         break;
                     case 2:
                         this._position = 0;
-                        this._playerManager.prevPlayer.stop();
-                        this._playerManager.currentPlayer.stop();
-                        this._stopNextChunkScheduling();
-                        this._chunkPosition = 0;
-                        this._chunkStartTime = undefined;
-                        this._tryResume = undefined;
-                        this._initFirstAudioChunk();
+                        this._loopOnRangeEnd();
                         this.play();
                         break;            
                     default:
@@ -369,16 +363,25 @@ export const AudioStreamPlayer = (() => {
             }
         }
 
-        stopOnRangeEndDefault() {
+        _stopOnRangeEndDefault() {
             this._playerManager.prevPlayer.stop();
             this._playerManager.currentPlayer.stop();
             this._stopNextChunkScheduling();
             this._chunkPosition = 0;
             this._chunkStartTime = undefined;
-            this._tryResume = undefined;
+            this._tryResume = undefined;           
+        }
+
+        _stopOnRangeEnd(){
+            this._stopOnRangeEndDefault();
             if (this.onStop) {
                 this.onStop();
             }
+            this._initFirstAudioChunk();
+        }
+
+        _loopOnRangeEnd(){
+            this._stopOnRangeEndDefault();
             this._initFirstAudioChunk();
         }
 

--- a/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
+++ b/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
@@ -96,7 +96,8 @@ export const AudioStreamPlayer = (() => {
                     return;
                 }
 
-                timeOffset = this.position % this._timePerChunk;
+                var startTime = this.position>=this._startRange?this.position:this._startRange;
+                timeOffset = startTime % this._timePerChunk;
             } else {
                 if (this._playerManager.currentPlayer.isScheduled) {
                     this._chunkStartTime = undefined;
@@ -188,7 +189,7 @@ export const AudioStreamPlayer = (() => {
             this._playerManager.prevPlayer.stop();
             this._playerManager.currentPlayer.stop();
             this._stopNextChunkScheduling();
-            this._position = this._startRange;
+            this._position = 0;
             this._chunkPosition = 0;
             this._chunkStartTime = undefined;
             this._tryResume = undefined;
@@ -343,12 +344,19 @@ export const AudioStreamPlayer = (() => {
                         this.stopOnRangeEndDefault();
                         break;
                     case 1:
-                        this._position = this._startRange;
+                        this._position = 0;
                         this.stopOnRangeEndDefault();
                         break;
                     case 2:
-                        this._position = this._startRange;
-                        this.play(0, true);
+                        this._position = 0;
+                        this._playerManager.prevPlayer.stop();
+                        this._playerManager.currentPlayer.stop();
+                        this._stopNextChunkScheduling();
+                        this._chunkPosition = 0;
+                        this._chunkStartTime = undefined;
+                        this._tryResume = undefined;
+                        this._initFirstAudioChunk();
+                        this.play();
                         break;            
                     default:
                         break;
@@ -371,7 +379,7 @@ export const AudioStreamPlayer = (() => {
             if (this.onStop) {
                 this.onStop();
             }
-            // this._initFirstAudioChunk();
+            this._initFirstAudioChunk();
         }
 
         /**

--- a/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
+++ b/src/main/resources/META-INF/resources/frontend/src/audio-stream-player.js
@@ -173,7 +173,13 @@ export const AudioStreamPlayer = (() => {
             if (this._chunkStartTime === undefined) {
                 this._chunkStartTime = this._getScheduleTime();
             }
-            this._playerManager.currentPlayer.play(this._chunkPosition, this._chunkStartTime / 1000);
+            const nextChunkLength = this._position + this._timePerChunk;
+            if(nextChunkLength > this._endRange){
+                const lastChunkDuration = this._endRange - this._position;
+                this._playerManager.currentPlayer.playByDuration(this._chunkPosition, this._chunkStartTime / 1000, lastChunkDuration / 1000);
+            } else {
+                this._playerManager.currentPlayer.play(this._chunkPosition, this._chunkStartTime / 1000);
+            }
             this._startNextChunkScheduling();
 
             const nextChunkTime = Math.min(

--- a/src/main/resources/META-INF/resources/frontend/src/buffer-player.js
+++ b/src/main/resources/META-INF/resources/frontend/src/buffer-player.js
@@ -39,6 +39,19 @@ export const BufferPlayer = (() => {
             this._sourceNode.start(when, offsetMillis / 1000);
         }
 
+        playByDuration(
+            offsetMillis,
+            when = this._context.currentTime +
+            Schedule.AUDIO_SCHEDULE_DELAY_MS / 1000,
+            duration
+        ) {
+            if (this.isScheduled) {
+                this.stop(when);
+            }
+            this._startTime = when;
+            this._sourceNode.start(when, offsetMillis / 1000, duration);
+        }
+
         stop(
             when = this._context.currentTime
             + Schedule.AUDIO_SCHEDULE_DELAY_MS / 1000

--- a/src/test/java/org/vaadin/addon/audio/demo/Controls.java
+++ b/src/test/java/org/vaadin/addon/audio/demo/Controls.java
@@ -5,6 +5,7 @@ import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.Uses;
@@ -15,6 +16,7 @@ import com.vaadin.flow.templatemodel.TemplateModel;
 import org.vaadin.addon.audio.server.AudioPlayer;
 import org.vaadin.addon.audio.server.state.PlaybackState;
 import org.vaadin.addon.audio.server.state.StateChangeCallback;
+import org.vaadin.addon.audio.server.util.OnEndOfRange;
 
 /**
  * A Designer generated component for the player-controls template.
@@ -45,6 +47,8 @@ public class Controls extends PolymerTemplate<Controls.PlayerControlsModel> impl
     private Button range2Button;
     @Id("range3")
     private Button range3Button;
+    @Id("onEndRangeOptions")
+    private ComboBox<OnEndOfRange> onEndRangeOptions;
     @Id("positionSlider")
     private SliderWithCaption positionSlider;
     @Id("volumeSlider")
@@ -68,6 +72,15 @@ public class Controls extends PolymerTemplate<Controls.PlayerControlsModel> impl
         setWidthFull();
         this.player = player;
         getElement().appendChild(player.getElement());
+
+        onEndRangeOptions.setLabel("On End Range");
+        onEndRangeOptions.setWidth("250px");
+        onEndRangeOptions.setItems(OnEndOfRange.values());
+        onEndRangeOptions.setItemLabelGenerator(OnEndOfRange::name);
+        onEndRangeOptions.setValue(player.getOnEndOfRange());
+        onEndRangeOptions.addValueChangeListener(e -> {
+            player.setOnEndOfRange(e.getValue());
+        });
 
         positionSlider.getSlider().addValueChangeListener(e -> {
             if (e.isFromClient()) {

--- a/src/test/java/org/vaadin/addon/audio/demo/Controls.java
+++ b/src/test/java/org/vaadin/addon/audio/demo/Controls.java
@@ -39,6 +39,12 @@ public class Controls extends PolymerTemplate<Controls.PlayerControlsModel> impl
     private Button playButton;
     @Id("forward5Button")
     private Button forward5Button;
+    @Id("range1")
+    private Button range1Button;
+    @Id("range2")
+    private Button range2Button;
+    @Id("range3")
+    private Button range3Button;
     @Id("positionSlider")
     private SliderWithCaption positionSlider;
     @Id("volumeSlider")
@@ -89,6 +95,21 @@ public class Controls extends PolymerTemplate<Controls.PlayerControlsModel> impl
             }
         });
         forward5Button.addClickListener(e -> player.skip(5000));
+
+        range1Button.addClickListener(e-> {
+            player.setStartRange(2000);
+            player.setEndRange(10000);
+        });
+
+        range2Button.addClickListener(e-> {
+            player.setStartRange(3000);
+            player.setEndRange(11000);
+        });
+
+        range3Button.addClickListener(e-> {
+            player.setStartRange(0);
+            player.setEndRange(player.getDuration());
+        });
 
         volumeSlider.getSlider().addValueChangeListener(e -> {
             Notification.show("Volume: " + e.getValue());

--- a/src/test/resources/META-INF/resources/frontend/player-controls.js
+++ b/src/test/resources/META-INF/resources/frontend/player-controls.js
@@ -52,6 +52,7 @@ class PlayerControls extends PolymerElement {
     <vaadin-button theme="primary" id="range3">
       Clear Ranges
     </vaadin-button> 
+    <vaadin-combo-box id = "onEndRangeOptions"></vaadin-combo-box>
    </vaadin-horizontal-layout> 
    <vaadin-horizontal-layout theme="margin" style="width: 100%; height: 100%;"> 
     <slider-with-caption id="volumeSlider" style="width: 250px" caption="Volume" value="1" max="10" step="0.1"></slider-with-caption> 

--- a/src/test/resources/META-INF/resources/frontend/player-controls.js
+++ b/src/test/resources/META-INF/resources/frontend/player-controls.js
@@ -43,6 +43,15 @@ class PlayerControls extends PolymerElement {
     <vaadin-button theme="primary" id="forward5Button">
       Forward 5 sec 
     </vaadin-button> 
+    <vaadin-button theme="primary" id="range1">
+      Set Range 2000-10000
+    </vaadin-button> 
+    <vaadin-button theme="primary" id="range2">
+      Set Range 3000-11000
+    </vaadin-button> 
+    <vaadin-button theme="primary" id="range3">
+      Clear Ranges
+    </vaadin-button> 
    </vaadin-horizontal-layout> 
    <vaadin-horizontal-layout theme="margin" style="width: 100%; height: 100%;"> 
     <slider-with-caption id="volumeSlider" style="width: 250px" caption="Volume" value="1" max="10" step="0.1"></slider-with-caption> 


### PR DESCRIPTION
- Add api to tell the tool to only play a specific millisecond-accurate range of the audio clip.  
- Add api to specify what should happen when playback reaches the end of the range.